### PR TITLE
made simple 8 bit alu with all the operations given

### DIFF
--- a/Simple_ALU/README.md
+++ b/Simple_ALU/README.md
@@ -4,7 +4,8 @@ Design and verify a 8-bit ALU which supports the following encoded operations:
 
 | Encoding | Operation | Comment                                         |
 |----------|-----------|-------------------------------------------------|
-| 3'b000   | ADD       | -                                               |
+| 3'b000   | ADD       | 
+-                                               |
 | 3'b001   | SUB       | -                                               |
 | 3'b010   | SLL       | Vector `a` should left shift using bits `2:0` of vector `b` |
 | 3'b011   | LSR       | Vector `a` should right shift using bits `2:0` of vector `b` |

--- a/Simple_ALU/simplealu.v
+++ b/Simple_ALU/simplealu.v
@@ -1,0 +1,22 @@
+module Simple_ALU (
+    input  logic [7:0] a_i,    
+    input  logic [7:0] b_i,     
+    input  logic [2:0] op_i,    
+    output logic [7:0] alu_o   
+);
+
+    always_comb begin
+        case (op_i)
+            3'b000: alu_o = a_i + b_i;                          
+            3'b001: alu_o = a_i - b_i;                          
+            3'b010: alu_o = a_i << b_i[2:0];                   
+            3'b011: alu_o = a_i >> b_i[2:0];                   
+            3'b100: alu_o = a_i & b_i;                          
+            3'b101: alu_o = a_i | b_i;                          
+            3'b110: alu_o = a_i ^ b_i;                          
+            3'b111: alu_o = (a_i == b_i) ? 8'd1 : 8'd0;         
+            default: alu_o = 8'd0;                         
+        endcase
+    end
+
+endmodule

--- a/Simple_ALU/simplealu_tb.v
+++ b/Simple_ALU/simplealu_tb.v
@@ -1,0 +1,45 @@
+module tb_Simple_ALU;
+
+    logic [7:0] a, b;
+    logic [2:0] op;
+    logic [7:0] result;
+
+   
+    Simple_ALU dut (
+        .a_i(a),
+        .b_i(b),
+        .op_i(op),
+        .alu_o(result)
+    );
+
+   
+    initial begin
+        //Sample inputs
+        a = 8'h3C;
+        b = 8'h0F;
+
+        $display("Testing Simple_ALU...");
+        for (int i = 0; i < 8; i++) begin
+            op = i[2:0];
+            #1; 
+            $display("op=%b a=%h b=%h result=%h", op, a, b, result);
+        end
+
+        //case 1:a == b
+        a = 8'hAA;
+        b = 8'hAA;
+        op = 3'b111;
+        #1;
+        $display("EQL test: a=%h b=%h result=%h", a, b, result);
+
+        //case 2: shift by max (7)
+        a = 8'h01;
+        b = 8'h07;
+        op = 3'b010; 
+        #1;
+        $display("SLL test: a=%h b=%h result=%h", a, b, result);
+
+        $finish;
+    end
+
+endmodule


### PR DESCRIPTION
I Implemented 8-bit Simple_ALU module supporting 8 operations via 3-bit opcode,
The Simple_ALU got affected

1)rtl.sv (module file) included
 2)tb.sv testbench included

ALU supports ADD, SUB, SLL, LSR, AND, OR, XOR, and EQL operations
Default case ensures safe fallback to 8'd0 
Testbench cycles through all opcodes with sample inputs; ready for waveform capture
Consider adding overflow flags or signed operation support in future iterations

`rtl.sv` (or module file) included
 `tb.sv` testbench included
 `README.md` for the module updated if behavior/usage changed
