### PR TITLE
Added an APB slave

### DIFF
--- a/APB_Slave/my_simulation
+++ b/APB_Slave/my_simulation
@@ -1,0 +1,216 @@
+#! /c/Source/iverilog-install/bin/vvp
+:ivl_version "12.0 (devel)" "(s20150603-1110-g18392a46)";
+:ivl_delay_selection "TYPICAL";
+:vpi_time_precision - 12;
+:vpi_module "C:\iverilog\lib\ivl\system.vpi";
+:vpi_module "C:\iverilog\lib\ivl\vhdl_sys.vpi";
+:vpi_module "C:\iverilog\lib\ivl\vhdl_textio.vpi";
+:vpi_module "C:\iverilog\lib\ivl\v2005_math.vpi";
+:vpi_module "C:\iverilog\lib\ivl\va_math.vpi";
+:vpi_module "C:\iverilog\lib\ivl\v2009.vpi";
+S_000002635d7ed5a0 .scope package, "$unit" "$unit" 2 1;
+ .timescale 0 0;
+S_000002635d7ed730 .scope module, "APB_Slave_tb" "APB_Slave_tb" 3 3;
+ .timescale -9 -12;
+v000002635d7e31d0_0 .var "clk", 0 0;
+v000002635d7e3770_0 .var "paddr_i", 9 0;
+v000002635d7e2f50_0 .var "penable_i", 0 0;
+v000002635d7e3270_0 .net "prdata_o", 31 0, v000002635d7eaf10_0;  1 drivers
+v000002635d7e3810_0 .net "pready_o", 0 0, v000002635d7eafb0_0;  1 drivers
+v000002635d7e2af0_0 .var "psel_i", 0 0;
+v000002635d7e2b90_0 .var "pwdata_i", 31 0;
+v000002635d7e2e10_0 .var "pwrite_i", 0 0;
+v000002635d7e2d70_0 .var "reset", 0 0;
+E_000002635d7d8540 .event anyedge, v000002635d7eafb0_0;
+S_000002635d7ed8c0 .scope module, "dut" "APB_Slave" 3 19, 4 1 0, S_000002635d7ed730;
+ .timescale -9 -12;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "reset";
+    .port_info 2 /INPUT 1 "psel_i";
+    .port_info 3 /INPUT 1 "penable_i";
+    .port_info 4 /INPUT 10 "paddr_i";
+    .port_info 5 /INPUT 1 "pwrite_i";
+    .port_info 6 /INPUT 32 "pwdata_i";
+    .port_info 7 /OUTPUT 32 "prdata_o";
+    .port_info 8 /OUTPUT 1 "pready_o";
+L_000002635d7ebe60 .functor AND 1, v000002635d7e2af0_0, v000002635d7e2f50_0, C4<1>, C4<1>;
+L_000002635d7eb7d0 .functor NOT 1, v000002635d7e2e10_0, C4<0>, C4<0>, C4<0>;
+v000002635d7e2c30_0 .net "clk", 0 0, v000002635d7e31d0_0;  1 drivers
+v000002635d7e2cd0_0 .net "paddr_i", 9 0, v000002635d7e3770_0;  1 drivers
+v000002635d7e33b0_0 .net "penable_i", 0 0, v000002635d7e2f50_0;  1 drivers
+v000002635d7e3310_0 .net "prdata_o", 31 0, v000002635d7eaf10_0;  alias, 1 drivers
+v000002635d7e3590_0 .net "pready_o", 0 0, v000002635d7eafb0_0;  alias, 1 drivers
+v000002635d7e3450_0 .net "psel_i", 0 0, v000002635d7e2af0_0;  1 drivers
+v000002635d7e34f0_0 .net "pwdata_i", 31 0, v000002635d7e2b90_0;  1 drivers
+v000002635d7e2a50_0 .net "pwrite_i", 0 0, v000002635d7e2e10_0;  1 drivers
+v000002635d7e3130_0 .net "reset", 0 0, v000002635d7e2d70_0;  1 drivers
+L_000002635d7e2ff0 .part v000002635d7e3770_0, 0, 4;
+S_000002635d7eac40 .scope module, "mem_inst" "Simple_Memory_Interface" 4 15, 5 1 0, S_000002635d7ed8c0;
+ .timescale -9 -12;
+    .port_info 0 /INPUT 1 "clk";
+    .port_info 1 /INPUT 1 "reset";
+    .port_info 2 /INPUT 1 "req_i";
+    .port_info 3 /INPUT 1 "req_rnw_i";
+    .port_info 4 /INPUT 4 "req_addr_i";
+    .port_info 5 /INPUT 32 "req_wdata_i";
+    .port_info 6 /OUTPUT 1 "req_ready_o";
+    .port_info 7 /OUTPUT 32 "req_rdata_o";
+v000002635d79bc50_0 .net "clk", 0 0, v000002635d7e31d0_0;  alias, 1 drivers
+v000002635d79bcf0_0 .var/i "i", 31 0;
+v000002635d7b2e90 .array "mem", 15 0, 31 0;
+v000002635d7eadd0_0 .net "req_addr_i", 3 0, L_000002635d7e2ff0;  1 drivers
+v000002635d7eae70_0 .net "req_i", 0 0, L_000002635d7ebe60;  1 drivers
+v000002635d7eaf10_0 .var "req_rdata_o", 31 0;
+v000002635d7eafb0_0 .var "req_ready_o", 0 0;
+v000002635d7eb050_0 .net "req_rnw_i", 0 0, L_000002635d7eb7d0;  1 drivers
+v000002635d7da1a0_0 .net "req_wdata_i", 31 0, v000002635d7e2b90_0;  alias, 1 drivers
+v000002635d7e36d0_0 .net "reset", 0 0, v000002635d7e2d70_0;  alias, 1 drivers
+E_000002635d7d84c0 .event posedge, v000002635d79bc50_0;
+    .scope S_000002635d7eac40;
+T_0 ;
+    %wait E_000002635d7d84c0;
+    %load/vec4 v000002635d7e36d0_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.0, 8;
+    %pushi/vec4 0, 0, 1;
+    %assign/vec4 v000002635d7eafb0_0, 0;
+    %pushi/vec4 0, 0, 32;
+    %assign/vec4 v000002635d7eaf10_0, 0;
+    %pushi/vec4 0, 0, 32;
+    %store/vec4 v000002635d79bcf0_0, 0, 32;
+T_0.2 ;
+    %load/vec4 v000002635d79bcf0_0;
+    %cmpi/s 16, 0, 32;
+    %jmp/0xz T_0.3, 5;
+    %pushi/vec4 0, 0, 32;
+    %ix/getv/s 3, v000002635d79bcf0_0;
+    %ix/load 4, 0, 0; Constant delay
+    %assign/vec4/a/d v000002635d7b2e90, 0, 4;
+    %load/vec4 v000002635d79bcf0_0;
+    %addi 1, 0, 32;
+    %store/vec4 v000002635d79bcf0_0, 0, 32;
+    %jmp T_0.2;
+T_0.3 ;
+    %jmp T_0.1;
+T_0.0 ;
+    %load/vec4 v000002635d7eae70_0;
+    %assign/vec4 v000002635d7eafb0_0, 0;
+    %load/vec4 v000002635d7eafb0_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.4, 8;
+    %load/vec4 v000002635d7eb050_0;
+    %flag_set/vec4 8;
+    %jmp/0xz  T_0.6, 8;
+    %load/vec4 v000002635d7eadd0_0;
+    %pad/u 6;
+    %ix/vec4 4;
+    %load/vec4a v000002635d7b2e90, 4;
+    %assign/vec4 v000002635d7eaf10_0, 0;
+    %jmp T_0.7;
+T_0.6 ;
+    %load/vec4 v000002635d7da1a0_0;
+    %load/vec4 v000002635d7eadd0_0;
+    %pad/u 6;
+    %ix/vec4 3;
+    %ix/load 4, 0, 0; Constant delay
+    %assign/vec4/a/d v000002635d7b2e90, 0, 4;
+T_0.7 ;
+T_0.4 ;
+T_0.1 ;
+    %jmp T_0;
+    .thread T_0;
+    .scope S_000002635d7ed730;
+T_1 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e31d0_0, 0, 1;
+T_1.0 ;
+    %delay 5000, 0;
+    %load/vec4 v000002635d7e31d0_0;
+    %inv;
+    %store/vec4 v000002635d7e31d0_0, 0, 1;
+    %jmp T_1.0;
+    %end;
+    .thread T_1;
+    .scope S_000002635d7ed730;
+T_2 ;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v000002635d7e2d70_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2af0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2f50_0, 0, 1;
+    %pushi/vec4 0, 0, 10;
+    %store/vec4 v000002635d7e3770_0, 0, 10;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2e10_0, 0, 1;
+    %pushi/vec4 0, 0, 32;
+    %store/vec4 v000002635d7e2b90_0, 0, 32;
+    %delay 10000, 0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2d70_0, 0, 1;
+    %delay 10000, 0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v000002635d7e2af0_0, 0, 1;
+    %pushi/vec4 10, 0, 10;
+    %store/vec4 v000002635d7e3770_0, 0, 10;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v000002635d7e2e10_0, 0, 1;
+    %pushi/vec4 3735928559, 0, 32;
+    %store/vec4 v000002635d7e2b90_0, 0, 32;
+    %wait E_000002635d7d84c0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v000002635d7e2f50_0, 0, 1;
+T_2.0 ;
+    %load/vec4 v000002635d7e3810_0;
+    %cmpi/ne 1, 0, 1;
+    %jmp/0xz T_2.1, 6;
+    %wait E_000002635d7d8540;
+    %jmp T_2.0;
+T_2.1 ;
+    %wait E_000002635d7d84c0;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2af0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2f50_0, 0, 1;
+    %delay 20000, 0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v000002635d7e2af0_0, 0, 1;
+    %pushi/vec4 10, 0, 10;
+    %store/vec4 v000002635d7e3770_0, 0, 10;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2e10_0, 0, 1;
+    %wait E_000002635d7d84c0;
+    %pushi/vec4 1, 0, 1;
+    %store/vec4 v000002635d7e2f50_0, 0, 1;
+T_2.2 ;
+    %load/vec4 v000002635d7e3810_0;
+    %cmpi/ne 1, 0, 1;
+    %jmp/0xz T_2.3, 6;
+    %wait E_000002635d7d8540;
+    %jmp T_2.2;
+T_2.3 ;
+    %wait E_000002635d7d84c0;
+    %load/vec4 v000002635d7e3270_0;
+    %cmpi/e 3735928559, 0, 32;
+    %jmp/0xz  T_2.4, 4;
+    %vpi_call/w 3 82 "$display", "SUCCESS: Read data matches written data!" {0 0 0};
+    %jmp T_2.5;
+T_2.4 ;
+    %vpi_call/w 3 84 "$error", "FAILURE: Read data mismatch! Expected 0x%h, Got 0x%h", 32'b11011110101011011011111011101111, v000002635d7e3270_0 {0 0 0};
+T_2.5 ;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2af0_0, 0, 1;
+    %pushi/vec4 0, 0, 1;
+    %store/vec4 v000002635d7e2f50_0, 0, 1;
+    %delay 100000, 0;
+    %vpi_call/w 3 91 "$finish" {0 0 0};
+    %end;
+    .thread T_2;
+# The file index is used to find the file name in the following table.
+:file_names 6;
+    "N/A";
+    "<interactive>";
+    "-";
+    "tb.sv";
+    "rtl.sv";
+    "simple_memory_interface.sv";

--- a/APB_Slave/rtl.sv
+++ b/APB_Slave/rtl.sv
@@ -1,0 +1,26 @@
+module APB_Slave (
+  // APB Interface
+  input         wire        clk,
+  input         wire        reset,
+  input         wire        psel_i,
+  input         wire        penable_i,
+  input         wire [9:0]  paddr_i,
+  input         wire        pwrite_i,
+  input         wire [31:0] pwdata_i,
+  output        wire [31:0] prdata_o,
+  output        wire        pready_o
+);
+
+  // Instantiate the Simple_Memory_Interface
+  Simple_Memory_Interface mem_inst (
+    .clk(clk),
+    .reset(reset),
+    .req_i(psel_i & penable_i),
+    .req_rnw_i(~pwrite_i),
+    .req_addr_i(paddr_i[3:0]),
+    .req_wdata_i(pwdata_i),
+    .req_ready_o(pready_o),
+    .req_rdata_o(prdata_o)
+  );
+
+endmodule

--- a/APB_Slave/simple_memory_interface.sv
+++ b/APB_Slave/simple_memory_interface.sv
@@ -1,0 +1,35 @@
+module Simple_Memory_Interface (
+  input       wire        clk,
+  input       wire        reset,
+
+  input       wire        req_i,
+  input       wire        req_rnw_i,    // 1 for read, 0 for write
+  input       wire[3:0]   req_addr_i,
+  input       wire[31:0]  req_wdata_i,
+  output      reg         req_ready_o,
+  output      wire[31:0]  req_rdata_o   // Changed to wire for combinational assignment
+);
+
+  // Memory array
+  logic [15:0][31:0] mem;
+
+  // Ready logic: Acknowledge the request on the next clock cycle
+  always @(posedge clk or posedge reset) begin
+    if (reset) begin
+      req_ready_o <= 1'b0;
+    end else begin
+      req_ready_o <= req_i;
+    end
+  end
+
+  // Write logic: Perform the write when the request is acknowledged
+  always @(posedge clk) begin
+    if (req_i && req_ready_o && !req_rnw_i) begin // Write operation
+      mem[req_addr_i] <= req_wdata_i;
+    end
+  end
+
+  // Read logic: Combinational read
+  assign req_rdata_o = mem[req_addr_i];
+
+endmodule

--- a/APB_Slave/tb.sv
+++ b/APB_Slave/tb.sv
@@ -1,0 +1,94 @@
+`timescale 1ns / 1ps
+
+module APB_Slave_tb;
+
+  // Inputs
+  logic        clk;
+  logic        reset;
+  logic        psel_i;
+  logic        penable_i;
+  logic [9:0]  paddr_i;
+  logic        pwrite_i;
+  logic [31:0] pwdata_i;
+
+  // Outputs
+  wire [31:0] prdata_o;
+  wire        pready_o;
+
+  // Instantiate the DUT
+  APB_Slave dut (
+    .clk(clk),
+    .reset(reset),
+    .psel_i(psel_i),
+    .penable_i(penable_i),
+    .paddr_i(paddr_i),
+    .pwrite_i(pwrite_i),
+    .pwdata_i(pwdata_i),
+    .prdata_o(prdata_o),
+    .pready_o(pready_o)
+  );
+
+  // Clock generation
+  initial begin
+    clk = 0;
+    forever #5 clk = ~clk;
+  end
+
+  // Test sequence
+  initial begin
+    // Initialize inputs
+    reset = 1;
+    psel_i = 0;
+    penable_i = 0;
+    paddr_i = 0;
+    pwrite_i = 0;
+    pwdata_i = 0;
+
+    // Apply reset
+    #10;
+    reset = 0;
+    #10;
+
+    // -- Write to memory --
+    psel_i = 1;
+    paddr_i = 4'hA;
+    pwrite_i = 1;
+    pwdata_i = 32'hDEADBEEF;
+    @(posedge clk);
+    penable_i = 1; // Assert penable in the ACCESS phase
+    
+    // Wait for the transaction to be acknowledged
+    wait (pready_o);
+    @(posedge clk);
+
+    // De-assert signals to end the transaction
+    psel_i = 0;
+    penable_i = 0;
+
+    // -- Read from memory --
+    #20;
+    psel_i = 1;
+    paddr_i = 4'hA;
+    pwrite_i = 0; // Set for a read operation
+    @(posedge clk);
+    penable_i = 1;
+    
+    // Wait for acknowledgement
+    wait (pready_o);
+
+    // Check the output on the next clock edge
+    @(posedge clk);
+    if (prdata_o == 32'hDEADBEEF) begin
+      $display("SUCCESS: Read data matches written data!");
+    end else begin
+      $error("FAILURE: Read data mismatch! Expected 0x%h, Got 0x%h", 32'hDEADBEEF, prdata_o);
+    end
+
+    psel_i = 0;
+    penable_i = 0;
+    
+    #100;
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
Short summary:
- Added a functional APB slave module with a corresponding testbench for verification.

Module:
This affects the APB_Slave module.
Checklist:
![21gtk](https://github.com/user-attachments/assets/9e54e120-a7ab-4818-8b94-6d86995d9abb)




Notes:
This implementation of the APB_Slave is dependent on the Simple_Memory_Interface module, which must be included in the project for successful compilation and simulation. The provided testbench verifies basic write and read operations.